### PR TITLE
View isInEditMode

### DIFF
--- a/MagicViews/circle.yml
+++ b/MagicViews/circle.yml
@@ -12,7 +12,8 @@ machine:
 
 dependencies:
   pre:
-    - echo y | android update sdk --no-ui --all --filter "tools,platform-tools,build-tools-23.0.2,android-23,extra-android-support,extra-google-google_play_services,extra-google-m2repository,extra-android-m2repository"
+    - echo y | android update sdk --no-ui --all --filter "tools,platform-tools,android-23,extra-android-support,extra-google-google_play_services,extra-google-m2repository,extra-android-m2repository"
+    - echo y | android update sdk --no-ui --all --filter build-tools-23.0.2
 
 test:
   override:

--- a/MagicViews/circle.yml
+++ b/MagicViews/circle.yml
@@ -12,7 +12,7 @@ machine:
 
 dependencies:
   pre:
-    - echo y | android update sdk --no-ui --all --filter "platform-tools,build-tools-23.0.2,android-23,extra-android-support,extra-google-google_play_services,extra-google-m2repository,extra-android-m2repository"
+    - echo y | android update sdk --no-ui --all --filter "tools,platform-tools,build-tools-23.0.2,android-23,extra-android-support,extra-google-google_play_services,extra-google-m2repository,extra-android-m2repository"
 
 test:
   override:

--- a/MagicViews/src/main/java/com/ivankocijan/magicviews/views/MagicAutoCompleteTextView.java
+++ b/MagicViews/src/main/java/com/ivankocijan/magicviews/views/MagicAutoCompleteTextView.java
@@ -30,12 +30,15 @@ public class MagicAutoCompleteTextView extends AppCompatAutoCompleteTextView imp
     }
 
     private void init(AttributeSet attrs) {
-        AttrsUtils.setAttributes(getContext(), attrs, this);
+        if (!isInEditMode()) {
+            AttrsUtils.setAttributes(getContext(), attrs, this);
+        }
     }
 
     @Override
     public void setFont(String fontName) {
-        FontUtils.setTypeface(getContext(), fontName, this);
-
+        if (!isInEditMode()) {
+            FontUtils.setTypeface(getContext(), fontName, this);
+        }
     }
 }

--- a/MagicViews/src/main/java/com/ivankocijan/magicviews/views/MagicButton.java
+++ b/MagicViews/src/main/java/com/ivankocijan/magicviews/views/MagicButton.java
@@ -25,23 +25,22 @@ public class MagicButton extends AppCompatButton implements MagicView {
 
     public MagicButton(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
-
-        if (!isInEditMode()) {
-            init(attrs);
-        }
+        init(attrs);
 
     }
 
     private void init(AttributeSet attrs) {
-
-        AttrsUtils.setAttributes(getContext(), attrs, this);
+        if (!isInEditMode()) {
+            AttrsUtils.setAttributes(getContext(), attrs, this);
+        }
 
     }
 
     @Override
     public void setFont(String fontName) {
-        FontUtils.setTypeface(getContext(), fontName, this);
-
+        if (!isInEditMode()) {
+            FontUtils.setTypeface(getContext(), fontName, this);
+        }
     }
 
 }

--- a/MagicViews/src/main/java/com/ivankocijan/magicviews/views/MagicCheckBox.java
+++ b/MagicViews/src/main/java/com/ivankocijan/magicviews/views/MagicCheckBox.java
@@ -24,22 +24,20 @@ public class MagicCheckBox extends AppCompatCheckBox implements MagicView {
 
     public MagicCheckBox(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
-
-        if (!isInEditMode()) {
-            init(attrs);
-        }
-
+        init(attrs);
     }
 
     private void init(AttributeSet attrs) {
-
-        AttrsUtils.setAttributes(getContext(), attrs, this);
-
+        if (!isInEditMode()) {
+            AttrsUtils.setAttributes(getContext(), attrs, this);
+        }
     }
 
     @Override
     public void setFont(String fontName) {
-        FontUtils.setTypeface(getContext(), fontName, this);
+        if (!isInEditMode()) {
+            FontUtils.setTypeface(getContext(), fontName, this);
+        }
     }
 
 }

--- a/MagicViews/src/main/java/com/ivankocijan/magicviews/views/MagicCheckedTextView.java
+++ b/MagicViews/src/main/java/com/ivankocijan/magicviews/views/MagicCheckedTextView.java
@@ -24,24 +24,21 @@ public class MagicCheckedTextView extends AppCompatCheckedTextView implements Ma
 
     public MagicCheckedTextView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
-
-        if (!isInEditMode()) {
-            init(attrs);
-        }
-
+        init(attrs);
     }
 
 
     private void init(AttributeSet attrs) {
-
-        AttrsUtils.setAttributes(getContext(), attrs, this);
-
+        if (!isInEditMode()) {
+            AttrsUtils.setAttributes(getContext(), attrs, this);
+        }
     }
 
     @Override
     public void setFont(String fontName) {
-        FontUtils.setTypeface(getContext(), fontName, this);
-
+        if (!isInEditMode()) {
+            FontUtils.setTypeface(getContext(), fontName, this);
+        }
     }
 
 }

--- a/MagicViews/src/main/java/com/ivankocijan/magicviews/views/MagicEditText.java
+++ b/MagicViews/src/main/java/com/ivankocijan/magicviews/views/MagicEditText.java
@@ -24,22 +24,20 @@ public class MagicEditText extends AppCompatEditText implements MagicView {
 
     public MagicEditText(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
-
-        if (!isInEditMode()) {
-            init(attrs);
-        }
+        init(attrs);
     }
 
     private void init(AttributeSet attrs) {
-
-        AttrsUtils.setAttributes(getContext(), attrs, this);
-
+        if (!isInEditMode()) {
+            AttrsUtils.setAttributes(getContext(), attrs, this);
+        }
     }
 
     @Override
     public void setFont(String fontName) {
-        FontUtils.setTypeface(getContext(), fontName, this);
-
+        if (!isInEditMode()) {
+            FontUtils.setTypeface(getContext(), fontName, this);
+        }
     }
 
 }

--- a/MagicViews/src/main/java/com/ivankocijan/magicviews/views/MagicMultiAutoCompleteTextView.java
+++ b/MagicViews/src/main/java/com/ivankocijan/magicviews/views/MagicMultiAutoCompleteTextView.java
@@ -30,15 +30,16 @@ public class MagicMultiAutoCompleteTextView extends AppCompatMultiAutoCompleteTe
     }
 
     private void init(AttributeSet attrs) {
-
-        AttrsUtils.setAttributes(getContext(), attrs, this);
-
+        if (!isInEditMode()) {
+            AttrsUtils.setAttributes(getContext(), attrs, this);
+        }
     }
 
     @Override
     public void setFont(String fontName) {
-        FontUtils.setTypeface(getContext(), fontName, this);
-
+        if (!isInEditMode()) {
+            FontUtils.setTypeface(getContext(), fontName, this);
+        }
     }
 
 

--- a/MagicViews/src/main/java/com/ivankocijan/magicviews/views/MagicRadioButton.java
+++ b/MagicViews/src/main/java/com/ivankocijan/magicviews/views/MagicRadioButton.java
@@ -30,13 +30,15 @@ public class MagicRadioButton extends AppCompatRadioButton implements MagicView 
     }
 
     private void init(AttributeSet attrs) {
-
-        AttrsUtils.setAttributes(getContext(), attrs, this);
-
+        if (!isInEditMode()) {
+            AttrsUtils.setAttributes(getContext(), attrs, this);
+        }
     }
 
     @Override
     public void setFont(String fontName) {
-        FontUtils.setTypeface(getContext(), fontName, this);
+        if (!isInEditMode()) {
+            FontUtils.setTypeface(getContext(), fontName, this);
+        }
     }
 }

--- a/MagicViews/src/main/java/com/ivankocijan/magicviews/views/MagicTextView.java
+++ b/MagicViews/src/main/java/com/ivankocijan/magicviews/views/MagicTextView.java
@@ -24,19 +24,20 @@ public class MagicTextView extends AppCompatTextView implements MagicView {
 
     public MagicTextView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
-
-        if (!isInEditMode()) {
-            init(attrs);
-        }
+        init(attrs);
     }
 
     private void init(AttributeSet attrs) {
-        AttrsUtils.setAttributes(getContext(), attrs, this);
+        if (!isInEditMode()) {
+            AttrsUtils.setAttributes(getContext(), attrs, this);
+        }
     }
 
     @Override
     public void setFont(String fontName) {
-        FontUtils.setTypeface(getContext(), fontName, this);
+        if (!isInEditMode()) {
+            FontUtils.setTypeface(getContext(), fontName, this);
+        }
     }
 }
 

--- a/TestApp/src/main/AndroidManifest.xml
+++ b/TestApp/src/main/AndroidManifest.xml
@@ -32,6 +32,10 @@
                 android:name=".activites.RecyclerViewExampleActivity"
                 android:label="@string/title_activity_recycler_view_example">
         </activity>
+        <activity
+                android:name=".activites.CustomViewActivity"
+                android:label="@string/title_activity_custom_view">
+        </activity>
     </application>
 
 </manifest>

--- a/TestApp/src/main/java/com/ivankocijan/TestApp/activites/CustomViewActivity.java
+++ b/TestApp/src/main/java/com/ivankocijan/TestApp/activites/CustomViewActivity.java
@@ -1,0 +1,18 @@
+package com.ivankocijan.TestApp.activites;
+
+import com.ivankocijan.TestApp.R;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+import butterknife.ButterKnife;
+
+public class CustomViewActivity extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_custom_view);
+        ButterKnife.inject(this);
+    }
+}

--- a/TestApp/src/main/java/com/ivankocijan/TestApp/activites/MainActivity.java
+++ b/TestApp/src/main/java/com/ivankocijan/TestApp/activites/MainActivity.java
@@ -45,4 +45,10 @@ public class MainActivity extends Activity {
         startActivity(new Intent(MainActivity.this, RecyclerViewExampleActivity.class));
 
     }
+
+    @OnClick(R.id.custom_view_example)
+    protected void goToCustomViewExample() {
+        startActivity(new Intent(MainActivity.this, CustomViewActivity.class));
+
+    }
 }

--- a/TestApp/src/main/java/com/ivankocijan/TestApp/views/CustomFrameLayout.java
+++ b/TestApp/src/main/java/com/ivankocijan/TestApp/views/CustomFrameLayout.java
@@ -1,0 +1,44 @@
+package com.ivankocijan.TestApp.views;
+
+import com.ivankocijan.TestApp.R;
+import com.ivankocijan.magicviews.views.MagicTextView;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.widget.FrameLayout;
+
+
+public class CustomFrameLayout extends FrameLayout {
+
+    public CustomFrameLayout(Context context) {
+        super(context);
+        init(context);
+    }
+
+    public CustomFrameLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init(context);
+    }
+
+    public CustomFrameLayout(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init(context);
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public CustomFrameLayout(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        init(context);
+    }
+
+    private void init(Context context) {
+        LayoutInflater.from(context).inflate(R.layout.layout_custom_frame_layout, this, true);
+        final MagicTextView magicTextView = (MagicTextView) getChildAt(0);
+        // font is added dynamically through code
+        // preview of this view should still be valid
+        magicTextView.setFont("galaxyfaraway.ttf");
+    }
+}

--- a/TestApp/src/main/res/layout/activity_custom_view.xml
+++ b/TestApp/src/main/res/layout/activity_custom_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="@dimen/default_padding">
+
+    <com.ivankocijan.TestApp.views.CustomFrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
+
+</LinearLayout>

--- a/TestApp/src/main/res/layout/activity_main.xml
+++ b/TestApp/src/main/res/layout/activity_main.xml
@@ -40,6 +40,12 @@
                 style="@style/Button.MainScreen"
                 app:typeFace="open_sans_semi_bold.ttf"/>
 
+        <com.ivankocijan.magicviews.views.MagicButton
+                android:text="@string/custom_view_example"
+                android:id="@+id/custom_view_example"
+                style="@style/Button.MainScreen"
+                app:typeFace="open_sans_semi_bold.ttf"/>
+
     </LinearLayout>
 
 

--- a/TestApp/src/main/res/layout/layout_custom_frame_layout.xml
+++ b/TestApp/src/main/res/layout/layout_custom_frame_layout.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+    <com.ivankocijan.magicviews.views.MagicTextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:padding="@dimen/default_padding"
+            android:text="@string/app_name"/>
+
+</merge>

--- a/TestApp/src/main/res/values/strings.xml
+++ b/TestApp/src/main/res/values/strings.xml
@@ -18,7 +18,9 @@
     <string name="button">Button</string>
     <string name="title_activity_code_example">CodeExampleActivity</string>
     <string name="title_activity_recycler_view_example">RecyclerViewExampleActivity</string>
+    <string name="title_activity_custom_view">CustomViewExampleActivity</string>
     <string name="recycler_view_example">RecyclerView example</string>
+    <string name="custom_view_example">Custom View example</string>
     <string name="example_item_s">Example item %s</string>
     <string name="load_items">Load items</string>
     <string name="list_is_empty">List is empty!</string>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Dec 09 10:08:09 CET 2014
+#Wed Feb 24 20:16:05 CET 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip


### PR DESCRIPTION
More often than not, when using MagicViews library, layout preview would break with an exception that font directory is empty. This is because the view tries to load the font even when in edit mode.

This may happen if a MagicView is used in another custom view and `setFont()` method is called in the code of the custom view.

Issue is avoided if all `init()` and `setFont()` methods in MagicViews are _wrapped_ with `isInEditMode()` method.

This PR introduces this change. It also adds an additional example which now demonstrates that layout preview has no issue displaying custom views.