### PR TITLE
AllowBackup value in Manifest

### DIFF
--- a/MagicViews/build.gradle
+++ b/MagicViews/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:2.1.3'
     }
 }
 

--- a/MagicViews/src/main/AndroidManifest.xml
+++ b/MagicViews/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.ivankocijan.magicviews">
 
-    <application android:allowBackup="true">
+    <application android:allowBackup="false">
 
     </application>
 

--- a/MagicViews/src/main/AndroidManifest.xml
+++ b/MagicViews/src/main/AndroidManifest.xml
@@ -1,8 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.ivankocijan.magicviews">
-
-    <application android:allowBackup="false">
-
-    </application>
+<manifest
+        package="com.ivankocijan.magicviews">
 
 </manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.1.3'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Feb 24 20:16:05 CET 2016
+#Thu Sep 01 09:57:02 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
"allowBackup:true" code block is automatically generated by Android Studio - libraries should have this value set to false in order to avoid failures with manifest merger.